### PR TITLE
fix: LDP-2307: remove locks for nodes to be deleted by drush testCleanup.

### DIFF
--- a/src/Drush/Commands/PlaywrightDrushCommands.php
+++ b/src/Drush/Commands/PlaywrightDrushCommands.php
@@ -257,9 +257,8 @@ class PlaywrightDrushCommands extends DrushCommands {
       $nodes = $node_storage->loadMultiple($nids);
       if (!empty($nodes)) {
         if (\Drupal::hasService('content_lock')) {
-          // Release locks for all nodes. If this is not done: as of at least
-          // v8.x-2.3, content_lock_entity_predelete() does a hard redirect
-          // -outputting a HTML response to STDOUT- and exit().
+          // Never keep content with the specified keyword, regardless of lock
+          // status.
           /** @var \Drupal\content_lock\ContentLock\ContentLock $lock_service */
           $lock_service = \Drupal::service('content_lock');
           foreach ($nodes as $node) {


### PR DESCRIPTION
This is convenient for cleanup commands on websites with the content_lock module enabled.

(
It's especially _inconvenient_ that if content is still locked when this command runs, `content_lock_entity_predelete()` does not warn or log any message; instead it does a hard redirect -which outputs a HTML response to STDOUT- and `exit(0)`. This confusing behavior can be an extra incentive for people to just not clean up after tests. (https://www.drupal.org/project/content_lock/issues/2951652)

But that's a side note; this drush command should probably unlock and remove the content anyway, regardless whether that issue gets fixed.
)