### PR TITLE
LDP-1787: add translation commands and some URL tweaks

### DIFF
--- a/src/Drush/Commands/PlaywrightDrushCommands.php
+++ b/src/Drush/Commands/PlaywrightDrushCommands.php
@@ -242,7 +242,7 @@ class PlaywrightDrushCommands extends DrushCommands {
    * Add a translation to a content entity.
    *
    * If a translation already exists: do nothing - and exit without error, so
-   * the command can run repeatedly, (If a test fails because of missing
+   * the command can run repeatedly. (If a test fails because of missing
    * certain translated text, it's likely that the test should be changed to
    * take the already-present translated content into account.)
    *

--- a/tests/helpers/drupal-commands.js
+++ b/tests/helpers/drupal-commands.js
@@ -11,7 +11,8 @@ module.exports = {
    */
   visitNodeEditPage: async ([page, node_title]) => {
     const result = drush(`test:node-get-id "${node_title}"`);
-    return await page.goto('/node/' + result.toString() + '/edit?destination=admin/content');
+    const nid = result.toString().replace(/\s+$/,'');
+    return await page.goto(`/node/${nid}/edit?destination=admin/content`);
   },
 
   /**
@@ -22,7 +23,8 @@ module.exports = {
    */
   visitNodeLayoutPage: async ([page, node_title]) => {
     const result = drush(`test:node-get-id "${node_title}"`);
-    return await page.goto('/node/' + result.toString() + '/layout');
+    const nid = result.toString().replace(/\s+$/,'');
+    return await page.goto(`/node/${nid}/layout`);
   },
 
   /**
@@ -33,9 +35,10 @@ module.exports = {
    */
   visitNodeLayoutPreviewPage: async ([page, node_title]) => {
     const result = drush(`test:node-get-id "${node_title}"`);
+    const nid = result.toString().replace(/\s+$/,'');
     // We do not have to explicitly go to the frontend via an absolute URL,
     // since the backend path redirects to the frontend also.
-    return await page.goto('/node/' + result.toString() + '/layout-preview?auth=1');
+    return await page.goto(`/node/${nid}/layout-preview?auth=1`);
   },
 
   /**
@@ -46,7 +49,7 @@ module.exports = {
    */
   getNodeIdByTitle: async ([page, node_title]) => {
     const result = drush(`test:node-get-id "${node_title}"`);
-    return result.toString();
+    return result.toString().replace(/\s+$/,'');
   },
 
   /**
@@ -57,7 +60,9 @@ module.exports = {
    */
   visitNodeByTitle: async ([page, node_title]) => {
     const result = drush(`test:node-get-path "${node_title}"`);
-    return await page.goto(result.toString());
+    // Remove only newline; keep any trailing spaces (that should never exist).
+    const path = result.toString().replace(/\n+$/,'');
+    return await page.goto(path);
   },
 
 
@@ -72,7 +77,8 @@ module.exports = {
     if (!baseUrl) {
       baseUrl = process.env.SITE_ADMIN_BASE_URL;
     }
-    return await page.goto(baseUrl + '/api' + result.toString());
+    const path = result.toString().replace(/\n+$/,'');
+    return await page.goto(`${baseUrl}/api${path}`);
   },
 
   /**

--- a/tests/helpers/drupal-commands.js
+++ b/tests/helpers/drupal-commands.js
@@ -99,11 +99,12 @@ module.exports = {
    * Adds a translation to a content entity if none exists yet.
    *
    * This is an alternative to either importing translations as demo content or
-   * adding translations through the UI. The latter method has the disadvantage
-   * that if a translation is already present (because of a test being re-run)
-   * the UI behaves differently. This command changes nothing if the translation
-   * is already present; if the existing translation differs from the
-   * 'translation' argument, that's a sign the test should likely be changed.
+   * adding translations through the UI / Playwright JS directly. The latter
+   * method is complicated by the fact that if a translation is already present
+   * (because of a test being re-run), the UI behaves differently. This command
+   * changes nothing if the translation is already present; if the existing
+   * translation differs from the 'translation' argument, that's a sign the
+   * test should likely be changed.
    *
    * @param  {Array<{entity_type: String, entity_spec: String, langcode: String, translation: String}>} array
    *   Content entity type, specification to select entity of this type,

--- a/tests/helpers/drupal-commands.js
+++ b/tests/helpers/drupal-commands.js
@@ -58,6 +58,25 @@ module.exports = {
   },
 
   /**
+   * Finds entity ID via drush and returns it.
+   * @param  {Array<{page: Page, entity_type: String, label: String}>} array
+   *   Page object, entity type, specification to select entity of this type,
+   *   entity_spec must resolve to a single entity of the given type and can be
+   *   either a label, or a JSON object as '{"field/property": value, ...}'.
+   * @returns {Promise<string>} The result.
+   */
+  getEntityId: async ([page, entity_type, entity_spec]) => {
+    // The drush command supports base64 encoded JSON object to evade dealing
+    // with double quotes. entity_spec must not be encoded if it's just a
+    // label; encode it if it's a bracketed string with a "key": inside.
+    if (entity_spec.match(/^\s*{\s*".*"\s*:.*}\s*$/s)) {
+      entity_spec = btoa(entity_spec);
+    }
+    const result = drush(`test:entity-get-id "${entity_type}" "${entity_spec}"`);
+    return result.toString().replace(/\s+$/,'');
+  },
+
+  /**
    * Visits node path found by title via drush.
    * @param  {Array<{page: Page, node_title: String}>} array Page object and
    *   node title


### PR DESCRIPTION
1. Adds a `addEntityTranslation` function to the drupal object + accompanying drush command. (After some initial doubts, I now think it's generally useful - see comments.)
2. Adds an optional langcode to visitNodeEditPage
3. tweaks the output of drush commands in a way that should not make any difference.

Re. point 3: sorry if the PR becomes a mess now. I would have separated it out for separate review, but this would introduce a merge conflict in visitNodeEditPage.

The thing is: newlines are retained in drush command output. In the playwright trace log, it is visible that e.g. visitNodeEditPage visits `node/NID⏎/edit`, etc. And `getNodeIdByTitle()` returns a string `NID⏎`.
* Even though it apparently has no negative effects, I would prefer to remove the ⏎ character from these URLs / return values, to prevent any future weirdness.
* Regardless, this _is_ in principle a behavior change in e.g. the return value of `getNodeIdByTitle()` , that callers could have accounted for. We can probably still get away with the change, at this moment? All LDP tests run fine with the changes.
* 
I promise I verified all the changed/added commands (locally - I will push the changes to a PR which uses them, when a new playwright-drupal-utiils is released).
