### PR TITLE
fix: LDP-2431: Fix fatal error on form submit after visitNodeEditPage.

### DIFF
--- a/tests/helpers/drupal-commands.js
+++ b/tests/helpers/drupal-commands.js
@@ -16,7 +16,7 @@ module.exports = {
     const lang_prefix = langcode ? `/${langcode}` : '';
     const result = drush(`test:node-get-id "${node_title}"`);
     const nid = result.toString().replace(/\s+$/,'');
-    return await page.goto(`${lang_prefix}/node/${nid}/edit?destination=admin/content`);
+    return await page.goto(`${lang_prefix}/node/${nid}/edit?destination=/admin/content`);
   },
 
   /**


### PR DESCRIPTION
This made it impossible to visitNodeEditPage() and then press Unlock. See more detail at internal issue (point 3) if interested, but that's optional.