### PR TITLE
feat: LDP-2431: Add langcode parameter to visitNodeApyByTitle().

### DIFF
--- a/src/Drush/Commands/PlaywrightDrushCommands.php
+++ b/src/Drush/Commands/PlaywrightDrushCommands.php
@@ -241,6 +241,8 @@ class PlaywrightDrushCommands extends DrushCommands {
    *
    * @param string $title
    *   Title of the node.
+   * @param string $langcode
+   *   (Optional) language code to look up the path in.
    *
    * @return string
    *
@@ -251,11 +253,16 @@ class PlaywrightDrushCommands extends DrushCommands {
    * @command test:node-get-path-alias
    * @aliases ngpath-alias
    */
-  public function getNodePathAliasWithTitle(string $title): string {
+  public function getNodePathAliasWithTitle(string $title, $langcode = ''): string {
     $nodes = $this->getEntityTypeManager()->getStorage('node')->loadByProperties([
       'title' => $title,
     ]);
     if ($node = reset($nodes)) {
+      if ($langcode) {
+        return $this->getAliasManager()->getAliasByPath('/node/' . $node->id(), $langcode);
+      }
+      // Just a precaution in case getAliasByPath() changes its signature: do
+      // not pass langcode in the default case.
       return $this->getAliasManager()->getAliasByPath('/node/' . $node->id());
     }
     throw new \Exception("Could not find node with title '{$title}'");

--- a/tests/helpers/drupal-commands.js
+++ b/tests/helpers/drupal-commands.js
@@ -93,13 +93,18 @@ module.exports = {
    * @param  {Object[]} array Page object and node title
    * @return {Response} The response.
    */
-  visitNodeAPIByTitle: async ([page, node_title]) => {
-    const result = drush(`test:node-get-path-alias "${node_title}"`);
+  visitNodeAPIByTitle: async ([page, node_title, langcode = '']) => {
+    const result = drush(`test:node-get-path-alias "${node_title}" "${langcode}"`);
     let baseUrl = process.env.DRUPAL_BASE_URL;
     if (!baseUrl) {
       baseUrl = process.env.SITE_ADMIN_BASE_URL;
     }
-    const path = result.toString().replace(/\n+$/,'');
+    let path = result.toString().replace(/\n+$/,'');
+    if (langcode) {
+      // path is the path alias to the translated page, without language prefix.
+      // Prepend that.
+      path = `/${langcode}${path}`;
+    }
     return await page.goto(`${baseUrl}/api${path}`);
   },
 


### PR DESCRIPTION
This is just an addition in case we need it.

Tested in our project, with and without language parameter. Behaves as expected.