### PR TITLE
fix: MCD-851: Remove content_lock release before entity delete. 

### DIFF
--- a/src/Drush/Commands/PlaywrightDrushCommands.php
+++ b/src/Drush/Commands/PlaywrightDrushCommands.php
@@ -366,22 +366,6 @@ class PlaywrightDrushCommands extends DrushCommands {
     if (!empty($nids)) {
       $nodes = $node_storage->loadMultiple($nids);
       if (!empty($nodes)) {
-        if (\Drupal::hasService('content_lock')) {
-          // Never keep content with the specified keyword, regardless of lock
-          // status.
-          /** @var \Drupal\content_lock\ContentLock\ContentLock $lock_service */
-          $lock_service = \Drupal::service('content_lock');
-          foreach ($nodes as $node) {
-            if ($lock_service->isLockable($node)) {
-              $langcode = $node->language()->getId();
-              $data = $lock_service->fetchLock($node->id(), NULL, $langcode, 'node');
-              if ($data !== FALSE) {
-                $lock_service->release($node->id(), $langcode, '*');
-              }
-            }
-          }
-        }
-
         $node_storage->delete($nodes);
       }
     }


### PR DESCRIPTION
This is not necessary any more with content_lock 3.x - it only was with 2.x