### PR TITLE
improve: Add optional destination parameter to ILogInAs

### DIFF
--- a/tests/helpers/test-methods.js
+++ b/tests/helpers/test-methods.js
@@ -6,8 +6,13 @@ module.exports = {
     await expect(page.locator('body.user-logged-in').first()).toHaveCount(0);
     await expect(page).toHaveURL(/.*user\/login/);
   },
-  ILogInAs: async ([page, username]) => {
-    await page.goto('/user/login');
+  ILogInAs: async ([page, username, destination]) => {
+    // Optionally set a destination to control the post-login redirect. This
+    // can be used to avoid being redirected to the admin dashboard, which
+    // renders views blocks that can cause race conditions during parallel
+    // test execution. Example: ILogInAs([page, 'dru_admin', '/user'])
+    const loginUrl = destination ? `/user/login?destination=${destination}` : '/user/login';
+    await page.goto(loginUrl);
     await expect(page.locator('form.user-login-form')).toBeVisible;
     await page.locator('input[name="name"]').fill(username);
     await page.locator('input[name="pass"]').fill(process.env.APP_SECRET);


### PR DESCRIPTION
## Summary
- Adds an optional `destination` parameter to `ILogInAs` to control the post-login redirect
- Can be used to avoid being redirected to the admin dashboard after login, which renders views blocks that can cause race conditions during parallel test execution
- Backwards compatible: existing callers are unaffected (no destination = default Drupal behavior)

## Usage
```javascript
// Default behavior (no change):
ILogInAs([page, 'dru_admin'])

// Skip dashboard redirect (for parallel tests):
ILogInAs([page, 'dru_admin', '/user'])
```