### PR TITLE
fix: MCD-993: Use page.waitForFunction for hydration helpers

### DIFF
--- a/tests/helpers/test-methods.js
+++ b/tests/helpers/test-methods.js
@@ -154,38 +154,20 @@ module.exports = {
    * Wait for Nuxt hydration to complete before running tests.
    * @param {Page} page The page to wait for.
    */
-  waitForNuxtHydration: async (page) => {
-    await page.evaluate(async () => {
-      return new Promise((resolve) => {
-        // Check if hydration has already completed.
-        if (window.lupusNuxtHydrationComplete) {
-          resolve(true);
-          return;
-        }
-        // Otherwise, wait for the event.
-        window.addEventListener('lupus-nuxt:loading:end', () => resolve(true), {
-          once: true,
-        });
-      });
-    });
+  waitForNuxtHydration: async (page, { timeout = 10000 } = {}) => {
+    await page.waitForFunction(
+      () => window.lupusNuxtHydrationComplete === true,
+      { timeout, polling: 'raf' },
+    );
   },
   /**
    * Wait for Nuxt to be ready before running tests.
    * @param {Page} page The page to wait for.
    */
-  waitForNuxtToBeReady: async (page) => {
-    await page.evaluate(async () => {
-      return new Promise((resolve) => {
-        // Check if Nuxt is already ready.
-        if (window.lupusNuxtReady) {
-          resolve(true);
-          return;
-        }
-        // Otherwise, wait for the event.
-        window.addEventListener('lupus-nuxt:ready', () => resolve(true), {
-          once: true,
-        });
-      });
-    });
+  waitForNuxtToBeReady: async (page, { timeout = 10000 } = {}) => {
+    await page.waitForFunction(
+      () => window.lupusNuxtReady === true,
+      { timeout, polling: 'raf' },
+    );
   },
 };


### PR DESCRIPTION
## Summary
- Replace `page.evaluate`-based hydration waits with `page.waitForFunction` in `waitForNuxtHydration` and `waitForNuxtToBeReady`
- `waitForFunction` survives execution-context destruction caused by Vue Router's `history.replaceState()` during SSR hydration
- Fixes flaky `frontend-gallery-hash-navigation` spec on LDP 25.x CI (~43% failure rate)

## Root cause
Vue Router calls `history.replaceState()` during SSR hydration to inject route state. Chrome fires `Page.navigatedWithinDocument` which destroys Playwright's evaluate execution context. `page.evaluate` with a long-lived Promise dies; `page.waitForFunction` re-evaluates across context transitions by design.

Confirmed via CDP instrumentation on CI (captured `navigationType: "historyApi"` event 10ms before the evaluate error).

## Test plan
- [x] Verified fix on LDP CI: PR #2645 build passed with composer patch applying this change
- [ ] Merge this PR, release new version
- [ ] Update LDP to use new release, remove composer patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)