### PR TITLE
feat: MCD-1116: Add watchdogIgnorePatterns option to the watchdog fixture.

### DIFF
--- a/tests/helpers/ldp-test.js
+++ b/tests/helpers/ldp-test.js
@@ -6,17 +6,24 @@ exports.test = base.test.extend({
   backendURL: ['http://admin--example.ldp-project.localdev.space', { option: true }],
   backendApiURL: ['http://admin--example.ldp-project.localdev.space/api', { option: true }],
   frontendURL: ['http://example.ldp-project.localdev.space', { option: true }],
-  watchdog: [async ({}, use, testInfo) => {
+  // Regex strings; watchdog errors whose message matches any of them are
+  // treated as accepted noise and do not fail the test. The watchdog table is
+  // site-wide, so this is the only way to tolerate known warnings produced by
+  // concurrently running specs without failing unrelated tests.
+  watchdogIgnorePatterns: [[], { option: true }],
+  watchdog: [async ({ watchdogIgnorePatterns }, use, testInfo) => {
     await use();
     const watchdog_errors = await drupal.checkWatchdogErrors(Math.floor(testInfo['_startWallTime'] / 1000), true, true)
-    if (parseInt(watchdog_errors['numberOfErrors']) > 0) {
-      watchdog_errors['errors'].map((error) => testInfo.errors.push({
-        message: `Watchdog item ID: ${error['wid']}
+    const ignorePatterns = watchdogIgnorePatterns.map((pattern) => new RegExp(pattern));
+    const errors = watchdog_errors['errors'].filter(
+      (error) => !ignorePatterns.some((pattern) => pattern.test(String(error['message'])))
+    );
+    errors.map((error) => testInfo.errors.push({
+      message: `Watchdog item ID: ${error['wid']}
 type: ${error['type']}
 severity: ${error['severity']}
 message: ${error['message']}`
-      }))
-    }
-    expect(parseInt(watchdog_errors['numberOfErrors'])).toEqual(0);
+    }))
+    expect(errors.length).toEqual(0);
   }, { scope: 'test', auto: true }]
 });


### PR DESCRIPTION
## Summary

Adds a `watchdogIgnorePatterns` fixture option (array of regex strings, default `[]`) to the `watchdog` fixture in `tests/helpers/ldp-test.js`. Watchdog errors whose rendered message matches any pattern are dropped before the zero-errors assertion.

Why: the watchdog table is site-wide, so a single known-noise warning produced by one spec fails every concurrently running spec. Projects can now accept a specific, well-understood warning (set via the playwright config `use` block, like `backendURL`) without weakening the check for anything else.

First consumer: ldp-project ignores the `array_flip(): Can only flip string and integer values … loadMultipleRevisions()` warning — a parallel-phase race where a concurrently running spec deletes a node between an admin listing's view query and its row operation-links rendering (see MCD-1116 for the full stack analysis). Companion ldp-project PR pins `^1.6.3`, so please tag **1.6.3** after merging.

Refs: MCD-1116

---
_Drafted with Claude Code from claude-vm-2._